### PR TITLE
fixed validation errors 

### DIFF
--- a/manifests/plugins/oracle/config.pp
+++ b/manifests/plugins/oracle/config.pp
@@ -6,7 +6,7 @@ class dmlite::plugins::oracle::config (
     $dbpool_max		= $dmlite::plugins::oracle::params::dbpool_max,
     $mapfile		= $dmlite::plugins::oracle::params::mapfile,
     $host_dn_is_root	= $dmlite::plugins::oracle::params::host_dn_is_root,
-    $enable_ns		= $dmlite::plugins::oracle::params::enable_ns
+    $enable_ns		= $dmlite::plugins::oracle::params::enable_ns,
     $user               = $dmlite::params::user,
     $group              = $dmlite::params::group
 ) inherits dmlite::plugins::oracle::params {

--- a/manifests/xrootd.pp
+++ b/manifests/xrootd.pp
@@ -212,13 +212,13 @@ class dmlite::xrootd (
 
   if ($log_style_param == "-k fifo") {  # delete all non-fifo files
     exec{"delete .xrootd.log files":
-      command => "/bin/find /var/log/xrootd -type f -name .xrootd.log -exec rm {} \;",
+      command => "/bin/find /var/log/xrootd -type f -name .xrootd.log -exec rm {} \\;",
       path    => "/bin/:/usr/bin/",
       unless  => '[ "`/bin/find /var/log/xrootd -type f -name .xrootd.log -type f`" = "" ]'
     }
   } else {  # do not use fifos, so delete all fifo files
     exec{"delete .xrootd.log files":
-      command => "/bin/find /var/log/xrootd -type f -name .xrootd.log -exec rm {} \;",
+      command => "/bin/find /var/log/xrootd -type f -name .xrootd.log -exec rm {} \\;",
       path    => "/bin/:/usr/bin/",
       unless  => '[ "`/bin/find /var/log/xrootd -type f -name .xrootd.log -type p`" = "" ]'
     }


### PR DESCRIPTION
Fixing errors in two puppet manifests (see diff).

Commands used (needs Gemfile & Rakefile, see below):
```shell
bundle exec rake validate
ruby -c lib/puppet/parser/functions/map_hash.rb
Syntax OK
---> syntax:manifests
rake aborted!
Could not parse for environment *root*: Syntax error at 'user'; expected ')' at /storage/Workspace/Configuration/puppet-dmlite/manifests/plugins/oracle/config.pp:10
Unrecognised escape sequence '\;' in file /storage/Workspace/Configuration/puppet-dmlite/manifests/xrootd.pp at line 215
Unrecognised escape sequence '\;' in file /storage/Workspace/Configuration/puppet-dmlite/manifests/xrootd.pp at line 22
```

If you want I can setup travis for this project which would involve these 3 files:
 - [.travis.yml](https://gist.github.com/kreczko/327b29645d7700e7f043#file-travis-yml)
 - [Gemfile](https://gist.github.com/kreczko/327b29645d7700e7f043#file-gemfile)
 - [Rakefile](https://gist.github.com/kreczko/327b29645d7700e7f043#file-rakefile)

which would check the consistency of this module every time code is changed (once travis-ci.org hook is enabled).

I also had a look at the (non-crucial) puppet-lint output:
https://gist.github.com/kreczko/327b29645d7700e7f043#file-dmlite-lint
but that's quite a bit to fix for one afternoon.

Please let me know if you wish to have a pull request for any of the above (.travis.yml, Gemfile, Rakefile).