### PR TITLE
CI link is now pointing to the log

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It's the base puppet module for the configuration of Data Management components 
 
 ###CI builds
 
-[![Build Status](https://travis-ci.org/cern-it-sdc-id/puppet-dmlite.svg?branch=master)]([https://travis-ci.org/cern-it-sdc-id/puppet-dmlite.svg)
+[![Build Status](https://travis-ci.org/cern-it-sdc-id/puppet-dmlite.svg?branch=master)](https://travis-ci.org/cern-it-sdc-id/puppet-dmlite)
 
 ### License
 ASL 2.0


### PR DESCRIPTION
Small change for the CI build image: the link now points to the build log so it is easier to check what is going wrong.

Last one for today, promise!