### PR TITLE
Two small things

### DIFF
--- a/manifests/dav/config.pp
+++ b/manifests/dav/config.pp
@@ -48,7 +48,9 @@ class dmlite::dav::config (
 
   Class[Dmlite::Dav::Install] -> Class[Dmlite::Dav::Config]
 
-  if($::selinux != false) {
+  # some installations don't have complete data types enabled by default, use
+  # str2bool to catch both cases
+  if(str2bool("${::selinux}") != false) {
     selboolean{'httpd_can_network_connect': value => on, persistent => true }
     selboolean{'httpd_execmem': value => on, persistent => true }
   }

--- a/manifests/head_hdfs.pp
+++ b/manifests/head_hdfs.pp
@@ -27,21 +27,21 @@ class dmlite::head_hdfs (
   class{'dmlite::install':
     debuginfo => $debuginfo
   }
- 
+
   Class[Dmlite::Plugins::Hdfs::Install] -> Class[Dmlite::Plugins::Hdfs::Config]
 
-  class{'dmlite::plugins::hdfs::config':
-    token_password	=> "${token_password}",
-    token_id		=> "${token_id}",
-    token_life	 	=> "${token_life}",
-    hdfs_namenode	=> "${hdfs_namenode}",
-    hdfs_port		=> "${hdfs_port}",
-    hdfs_user		=> "${hdfs_user}",
-    hdfs_mode		=> "${hdfs_mode}",
-    hdfs_gateway	=> "${hdfs_gateway}",
-    hdfs_tmp_folder	=> "${hdfs_tmp_folder}",
-    enable_io		=> "${enable_io}",
-    enable_ns		=> false,
+  class { 'dmlite::plugins::hdfs::config':
+    token_password  => "${token_password}",
+    token_id        => "${token_id}",
+    token_life      => "${token_life}",
+    hdfs_namenode   => "${hdfs_namenode}",
+    hdfs_port       => "${hdfs_port}",
+    hdfs_user       => "${hdfs_user}",
+    hdfs_mode       => "${hdfs_mode}",
+    hdfs_gateway    => "${hdfs_gateway}",
+    hdfs_tmp_folder => "${hdfs_tmp_folder}",
+    enable_io       => "${enable_io}",
+    enable_ns       => false,
   }
   class{'dmlite::plugins::hdfs::install':}
 


### PR DESCRIPTION
The first is just indentation, the second one is how bool facts are handled.
For site that don't have complete data types enabled, the solution is to use ```str2bool``` for both cases:
https://docs.puppetlabs.com/puppet/latest/reference/lang_facts_and_builtin_vars.html#data-types