### PR TITLE
Campatibility with puppet-3.8.3

### DIFF
--- a/manifests/dav/config.pp
+++ b/manifests/dav/config.pp
@@ -143,7 +143,7 @@ class dmlite::dav::config (
     }
   }
  #centOS7 changes
- if $::operatingsystemmajrelease and $::operatingsystemmajrelease >= 7 { 
+ if $::operatingsystemmajrelease and ($::operatingsystemmajrelease + 0) >= 7 { 
      file {
       '/etc/httpd/conf.modules.d/00-dav.conf':
         ensure  => absent,


### PR DESCRIPTION
Hi,

while upgrading to puppet 3.8.3 I've had some problems with the lcgdm and dmlite module. Here are a couple of proposed corrections to these modules. I've made few tests and they seem to work both with 3.8.3 and with 3.4.3 (the version I was using before)

Cheers,
andrea 