### PR TITLE
made java_home a hiera lookup for HDFS plugin

### DIFF
--- a/manifests/plugins/hdfs/params.pp
+++ b/manifests/plugins/hdfs/params.pp
@@ -8,13 +8,13 @@ class dmlite::plugins::hdfs::params (
     $hdfs_port = undef
     $hdfs_user = undef
     $hdfs_mode = rw
-    $hdfs_gateway = "${::fqdn}"
+    $hdfs_gateway = $::fqdn
     $hdfs_tmp_folder = '/tmp'
     $hdfs_replication = 3
     $hadoop_home_lib = '/usr/lib/hadoop'
     $hdfs_home_lib = '/usr/lib/hadoop-hdfs'
     $hadoop_conf_folder= '/etc/hadoop/conf'
-    $java_home = '/usr/lib/jvm/java/'
+    $java_home = hiera('dmlite::plugins::hdfs::params::java_home', '/usr/lib/jvm/java/')
     $token_password = 'change-this'
     $map_file = '/etc/lcgdm-mapfile'
     $token_id = ip


### PR DESCRIPTION
Following up the changed needed for CDH 5.7, made the java_home parameter an explicit hiera lookup.