### PR TITLE
Modification needed for new cms federation config

### DIFF
--- a/manifests/xrootd.pp
+++ b/manifests/xrootd.pp
@@ -156,8 +156,7 @@ class dmlite::xrootd (
       alice_token_principal => $alice_token_principal,
       alice_token_libname   => $alice_token_libname,
       alice_fqans           => $alice_fqans,
-      dpm_xrootd_fedredirs  => $dpm_xrootd_fedredirs
-
+      dpm_xrootd_fedredirs  => $dpm_xrootd_fedredirs,
     }
     $l = size("${::fqdn}")
     if $l > 16 {
@@ -217,9 +216,10 @@ class dmlite::xrootd (
 
     }
 
+    $dpm_cmsd_fedredirs = $dpm_xrootd_fedredirs.filter | $fed,$value | { $value['cmsd_port']!=undef }
 
     $xrootd_instances_options_fed = map_hash($dpm_xrootd_fedredirs, "-l /var/log/xrootd/xrootd.log -c /etc/xrootd/xrootd-dpmfedredir_%s.cfg ${log_style_param}")
-    $cmsd_instances_options_fed = map_hash($dpm_xrootd_fedredirs, "-l /var/log/xrootd/cmsd.log -c /etc/xrootd/xrootd-dpmfedredir_%s.cfg ${log_style_param}")
+    $cmsd_instances_options_fed = map_hash($dpm_cmsd_fedredirs, "-l /var/log/xrootd/cmsd.log -c /etc/xrootd/xrootd-dpmfedredir_%s.cfg ${log_style_param}")
 
   } else {
     $xrootd_instances_options_redir = {}
@@ -283,8 +283,9 @@ class dmlite::xrootd (
 
 		 if size($array_fed) > 0 {
 	        	 $array_fed_final =  prefix($array_fed,'dpmfedredir_')
+			 $array_cmsd = $array_fed.filter | $fed | {$dpm_xrootd_fedredirs[$fed]['cmsd_port']!=undef}
 			 $xrootd_instances = flatten (concat (['dpmredir'],$array_fed_final))
-  			 $cmsd_instances_final = prefix($array_fed_final,'cmsd@')
+  			 $cmsd_instances_final = prefix(prefix($array_cmsd,'dpmfedredir_'),'cmsd@')
 		 }
 		 else {
 			$xrootd_instances = ['dpmredir']

--- a/manifests/xrootd/create_redir_config.pp
+++ b/manifests/xrootd/create_redir_config.pp
@@ -6,6 +6,7 @@ define dmlite::xrootd::create_redir_config (
   $cmsd_port = undef,
   $local_port = undef,
   $paths = undef,
+  $direct = false,
 
   $namelib_prefix = undef,
   $namelib = undef,
@@ -63,7 +64,9 @@ define dmlite::xrootd::create_redir_config (
   # constructing variables from the parameters
   $pss_origin = "localhost:${local_port}"
   $xrd_port = $local_port
-  $all_manager = "${fed_host}+:${cmsd_port}"
+  if($cmsd_port){
+    $all_manager = "${fed_host}+:${cmsd_port}"
+  }
   $all_export = $paths
 
   $dpm_namelib = $namelib

--- a/templates/xrootd/dpm-xrootd.cfg.erb
+++ b/templates/xrootd/dpm-xrootd.cfg.erb
@@ -55,13 +55,15 @@ dpm.mmreqhost <%= @dpm_mmreqhost %>
 <%# federation redirects for the main config file %>
 <% if @dpm_xrootd_fedredirs and not @paths -%>
 <% @dpm_xrootd_fedredirs.sort.each do |fedname, redir| -%>
+<% if not redir['direct'] -%>
 <% redir['paths'].sort.each do |path| -%>
 xrootd.redirect <%= @dpm_host -%>:<%= redir['local_port'] -%> <%= File.join(path,"") %>
 <% end -%>
 <% end -%>
 <% end -%>
+<% end -%>
 <%# federation redirects for each federation config file %>
-<% if @paths -%>
+<% if @paths and @xrootd_port -%>
 <% @paths.sort.each do |path| -%>
 xrootd.redirect <%= @fed_host -%>:<%= @xrootd_port -%> ? <%= File.join(path,"") %>
 <% end -%>


### PR DESCRIPTION
Hi,
some modification on the dmlite xrootd template to allow for more flexible configuration needed for a new cms federation setup. Namenly
- if the 'cmsd_port' parameter is undefined the cmsd service is not started and the all_manager directive is not included in the config file
- if the 'xrootd_port' parameter is undefined the redirect directive is not included in the config file
- an additional parameter 'direct', if set to true, prevents the federation endpoint to be listed as a possible redirect in the main redir config

a configuration made with this new version of the module is currently running in prod at GRIF_LLR. 
I'm not sure this is the best way to achieve the desired configuration, so suggestions are welcome.