### PR TITLE
LCGDM-2699: Update ServerLimit to avoid stuck graceful restarts

### DIFF
--- a/templates/dav/mpm_event.conf
+++ b/templates/dav/mpm_event.conf
@@ -7,11 +7,17 @@
 # MaxRequestsPerChild: maximum number of requests a server process serves
 <IfModule mpm_event_module>
     StartServers          4
-    ServerLimit           4
+    ServerLimit          16
     MinSpareThreads       1
     MaxSpareThreads    1200
     ThreadLimit         300
     ThreadsPerChild     300
     MaxClients         1200
+<IfVersion >= 2.4>
+    MaxRequestWorkers  4800
+</IfVersion>
+<IfVersion < 2.4>
+    MaxClients         4800
+</IfVersion>
     MaxRequestsPerChild   100000
 </IfModule>


### PR DESCRIPTION
Trying to mitigate problems described in [LCGDM-2699](https://its.cern.ch/jira/browse/LCGDM-2699)
Changed also in the [DPM Tuning Hints](https://twiki.cern.ch/twiki/bin/view/DPM/DpmSetupTuningHints#Hint_Apache_httpd_threading_mode)
