### PR TITLE
Pass DB name between classes

### DIFF
--- a/manifests/db/dpm.pp
+++ b/manifests/db/dpm.pp
@@ -1,4 +1,5 @@
-class dmlite::db::dpm ($dbuser, $dbpass, $dbhost) inherits dmlite::db::params {
+class dmlite::db::dpm ($dbname, $dbuser, $dbpass, $dbhost) inherits dmlite::db::params {
+  include 'mysql::server'
 
   # the packaged db script explicitly creates the db, we don't want that
   file_line { 'dpm mysql commentcreate':
@@ -8,7 +9,7 @@ class dmlite::db::dpm ($dbuser, $dbpass, $dbhost) inherits dmlite::db::params {
     path   => '/usr/share/dmlite/dbscripts/dpm_mysql_db.sql'
   }
 
-  mysql::db { $dmlite::db::params::dpm_db:
+  mysql::db { $dbname:
     user     => "${dbuser}",
     password => "${dbpass}",
     host     => "${dbhost}",
@@ -24,14 +25,14 @@ class dmlite::db::dpm ($dbuser, $dbpass, $dbhost) inherits dmlite::db::params {
             password_hash => mysql_password($dbpass),
             provider      => 'mysql',
         }
-        mysql_grant { "${dbuser}@${::fqdn}/${dmlite::db::params::dpm_db}.*":
+        mysql_grant { "${dbuser}@${::fqdn}/${dbname}.*":
             ensure     => 'present',
             options    => ['GRANT'],
             privileges => ['ALL'],
             provider   => 'mysql',
             user       => "${dbuser}@${::fqdn}",
-            table      => "${dmlite::db::params::dpm_db}.*",
-            require    => [Mysql_database["${dmlite::db::params::dpm_db}"], Mysql_user["${dbuser}@${::fqdn}"], ],
+            table      => "${dbname}.*",
+            require    => [Mysql_database["${dbname}"], Mysql_user["${dbuser}@${::fqdn}"], ],
         }
   } 
 }

--- a/manifests/db/ns.pp
+++ b/manifests/db/ns.pp
@@ -1,4 +1,5 @@
-class dmlite::db::ns ($flavor , $dbuser, $dbpass, $dbhost) inherits dmlite::db::params {
+class dmlite::db::ns ($flavor , $dbname, $dbuser, $dbpass, $dbhost) inherits dmlite::db::params {
+  include 'mysql::server'
 
   # the packaged db script explicitly creates the db, we don't want that
   file_line { "${flavor} mysql commentcreate":
@@ -16,7 +17,7 @@ class dmlite::db::ns ($flavor , $dbuser, $dbpass, $dbhost) inherits dmlite::db::
     path   => "/usr/share/dmlite/dbscripts/cns_mysql_db.sql"
   }
 
-  mysql::db { $dmlite::db::params::ns_db:
+  mysql::db { $dbname:
     user     => "${dbuser}",
     password => "${dbpass}",
     host     => "${dbhost}",
@@ -26,14 +27,14 @@ class dmlite::db::ns ($flavor , $dbuser, $dbpass, $dbhost) inherits dmlite::db::
 
   if $dbhost != 'localhost'  and $dbhost != "${::fqdn}" {
         #create the database grants for the user
-        mysql_grant { "${dbuser}@${::fqdn}/${dmlite::db::params::ns_db}.*":
+        mysql_grant { "${dbuser}@${::fqdn}/${dbname}.*":
             ensure     => 'present',
             options    => ['GRANT'],
             privileges => ['ALL'],
             provider   => 'mysql',
             user       => "${dbuser}@${::fqdn}",
-            table      => "${dmlite::db::params::ns_db}.*",
-            require    => [Mysql_database["${dmlite::db::params::ns_db}"], Mysql_user["${dbuser}@${::fqdn}"], ],
+            table      => "${dbname}.*",
+            require    => [Mysql_database["${dbname}"], Mysql_user["${dbuser}@${::fqdn}"], ],
         }
   }
 

--- a/manifests/head.pp
+++ b/manifests/head.pp
@@ -214,6 +214,8 @@ class dmlite::head (
        db_host      => "${mysql_host}",
        db_user      => "${mysql_username}",
        db_password  => "${mysql_password}",
+       cnsdb_name   => "${ns_db}",
+       dpmdb_name   => "${dpm_db}",
        headnode_domeurl => "http://${dpmhost}:1094/domehead",
        restclient_cli_xrdhttpkey => "${token_password}"
      } 

--- a/manifests/head.pp
+++ b/manifests/head.pp
@@ -80,6 +80,7 @@ class dmlite::head (
     Package['dmlite-dpmhead-domeonly']
     ->
     class{'dmlite::db::dpm':
+      dbname => "${dpm_db}",
       dbuser => "${mysql_username}",
       dbpass => "${mysql_password}",
       dbhost => "${mysql_host}",
@@ -89,6 +90,7 @@ class dmlite::head (
     ->
     class{'dmlite::db::ns': 
       flavor => 'mysql',
+      dbname => "${ns_db}",
       dbuser => "${mysql_username}", 
       dbpass => "${mysql_password}",
       dbhost => "${mysql_host}",


### PR DESCRIPTION
To support non-default database name it is necessary to pass this attribute while creating DPM puppet classes. It would be nice to run dpmtrunk-rc with non-default names to test configuration that doesn't use 'dpm_db' and 'cns_db'.