### PR TITLE
allow to publish SRR directly with CGI

### DIFF
--- a/manifests/dav/config.pp
+++ b/manifests/dav/config.pp
@@ -34,6 +34,7 @@ class dmlite::dav::config (
   $libdir             = $dmlite::dav::libdir,
   $dav_http_port      = $dmlite::dav::dav_http_port,
   $dav_https_port     = $dmlite::dav::dav_https_port,
+  $enable_srr_cgi     = $dmlite::dav::enable_srr_cgi,
 ) {
   validate_bool($enable_ns)
   validate_bool($enable_disk)

--- a/manifests/dav/params.pp
+++ b/manifests/dav/params.pp
@@ -33,4 +33,5 @@ class dmlite::dav::params (
     $enable_keep_alive  = hiera('dmlite::dav::params::enable_keep_alive', true)
     $mpm_model          = hiera('dmlite::dav::params::mpm_model', '/usr/sbin/httpd.event')
     $enable_hdfs        = hiera('dmlite::dav::params::enable_hdfs', false)
+    $enable_srr_cgi     = hiera('dmlite::dav::params::enable_srr_cgi', true)
 }

--- a/templates/dav/zlcgdm-dav.conf
+++ b/templates/dav/zlcgdm-dav.conf
@@ -5,6 +5,11 @@
 # VirtualHosts. The actual VirtualHost instances are defined at the end of this file.
 #
 
+<%if @enable_srr_cgi -%>
+# publish WLCG SRR information online
+ScriptAlias /static/srr "/usr/bin/dpm-storage-summary.cgi"
+<% end -%>
+
 # Static content
 Alias /static/ /usr/share/lcgdm-dav/
 <Location "/static">


### PR DESCRIPTION
Publish by default SRR info at /static/srr (/static directory is by default excluded from DPM DAV apache configuration). SRR can be disabled by dmlite::dav::params::enable_srr_cgi configuration option.